### PR TITLE
feat: add crypto region

### DIFF
--- a/qlib/config.py
+++ b/qlib/config.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Callable, Optional, Union
 from typing import TYPE_CHECKING
 
-from qlib.constant import REG_CN, REG_US, REG_TW
+from qlib.constant import REG_CN, REG_US, REG_TW, REG_CRYPTO
 
 if TYPE_CHECKING:
     from qlib.utils.time import Freq
@@ -307,6 +307,12 @@ _default_region_config = {
         "trade_unit": 1000,
         "limit_threshold": 0.1,
         "deal_price": "close",
+    },
+    REG_CRYPTO: {
+        "trade_unit": 1,
+        "limit_threshold": None,
+        "deal_price": "close",
+        "provider_uri": "~/.qlib/qlib_data/crypto_data",
     },
 }
 

--- a/qlib/constant.py
+++ b/qlib/constant.py
@@ -10,6 +10,7 @@ import pandas as pd
 REG_CN = "cn"
 REG_US = "us"
 REG_TW = "tw"
+REG_CRYPTO = "crypto"
 
 # Epsilon for avoiding division by zero.
 EPS = 1e-12


### PR DESCRIPTION
## Summary
- add `REG_CRYPTO` constant for new crypto region
- allow `qlib.init(region="crypto")` with default crypto data path

## Testing
- `pre-commit run --files qlib/constant.py qlib/config.py` *(fails: AttributeError: 'EntryPoints' object has no attribute 'get')*
- `pytest` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a17ab098dc8320be0df968a398f9fa