### PR TITLE
docs: update crypto backtesting documentation

### DIFF
--- a/docs/crypto/overview.rst
+++ b/docs/crypto/overview.rst
@@ -3,9 +3,14 @@ Crypto Support Overview
 
 Architecture
 ------------
-* Data is fetched from public cryptocurrency APIs via libraries such as `ccxt` or `pycoingecko`.
+* Data is fetched from exchanges through ``ccxt`` (currently using the OKX API).
 * Raw responses are converted to Qlib format with the collector scripts in ``scripts/data_collector/crypto``.
-* Once prepared, datasets can be loaded through the standard ``qlib.data`` interface for research.
+* Once prepared, datasets (including OHLCV fields) can be loaded through the standard ``qlib.data`` interface for research.
+
+Backtesting
+-----------
+* OHLC data is now supported, enabling backtests through Qlib's workflow.
+* Use ``CryptoExchange`` with ``SimulatorExecutor`` or the template in ``examples/crypto/backtest_config.yaml`` to evaluate strategies on 24/7 markets.
 
 Installation
 ------------
@@ -14,12 +19,12 @@ Installation
 
    .. code-block:: bash
 
-      pip install ccxt loguru fire requests numpy pandas tqdm lxml pycoingecko
+      pip install ccxt loguru fire requests numpy pandas tqdm lxml
 
 Known Issues
 ------------
 * Public APIs may enforce rate limits and sometimes return incomplete data.
-* The example dataset from Coingecko lacks OHLC information, so backtesting is not supported.
+* Example datasets generated from the OKX API may have limited history and require additional cleaning before production use.
 * Qlib does **not** guarantee the accuracy or availability of third-party data. Prepare and verify your own dataset before trading.
 
 For a usage example, see ``scripts/data_collector/crypto/README.md``.

--- a/examples/crypto/backtest_config.yaml
+++ b/examples/crypto/backtest_config.yaml
@@ -1,6 +1,19 @@
 # Template configuration for cryptocurrency backtesting
-# This file serves as an example on how to configure the crypto exchange
-# and executor for 24/7 markets.
+#
+# Usage:
+#   1. Prepare an OHLCV dataset (e.g., with ``scripts/data_collector/crypto``
+#      which fetches data from the OKX API via ``ccxt``) and store it at the
+#      path specified by ``qlib_init.provider_uri`` (default: ``~/.qlib/crypto_data``).
+#      The data must contain open, high, low, close and volume fields at the
+#      desired frequency.
+#   2. Run your workflow or scripts with this configuration. For example:
+#      ``python examples/crypto/workflow.py --config examples/crypto/backtest_config.yaml``
+#      or load it via ``qlib.backtest`` APIs.
+#
+# Dataset limitations:
+#   - Only instruments present in the prepared dataset can be backtested.
+#   - Public sources such as OKX may provide incomplete history; verify data
+#     quality before relying on the results.
 
 qlib_init:
   provider_uri: "~/.qlib/crypto_data"


### PR DESCRIPTION
## Summary
- document OHLCV support and crypto backtesting workflow
- add usage instructions and dataset notes to crypto backtest config
- clarify that crypto datasets are sourced via OKX API

## Testing
- `pre-commit run --files docs/crypto/overview.rst examples/crypto/backtest_config.yaml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'qlib')*

------
https://chatgpt.com/codex/tasks/task_e_68a2dea32b4c83208d33409f1cb59221