### PR TITLE
Follow-up: fix pandas 1.x datetime parsing in IncrementalUpdater

### DIFF
--- a/qlib_crypto/collector/incremental.py
+++ b/qlib_crypto/collector/incremental.py
@@ -41,8 +41,8 @@ class IncrementalUpdater:
         )
 
     def _infer_start(self, df: pd.DataFrame) -> pd.Timestamp:
-        date_series = pd.to_datetime(df["date"], utc=True)
-        last_dt = date_series.max().tz_localize(None)
+        date_series = self._parse_date_series(df["date"])
+        last_dt = date_series.max()
         step = pd.Timedelta(days=1) if self.interval == "1d" else pd.Timedelta(minutes=1)
         return pd.Timestamp(last_dt) + step
 
@@ -52,6 +52,11 @@ class IncrementalUpdater:
         if ts.tz is not None:
             return ts.tz_convert("UTC").tz_localize(None)
         return ts
+
+    @classmethod
+    def _parse_date_series(cls, date_series: pd.Series) -> pd.Series:
+        parsed = date_series.map(pd.Timestamp)
+        return parsed.map(cls._normalize_ts)
 
     def update(self, end: Optional[str] = None, limit_nums: Optional[int] = None):
         files = sorted(self.source_dir.glob("*.csv"))
@@ -81,7 +86,7 @@ class IncrementalUpdater:
             new_df = new_df.copy()
             new_df["symbol"] = qlib_symbol
             merged = pd.concat([old_df, new_df], sort=False, ignore_index=True)
-            merged["date"] = pd.to_datetime(merged["date"], utc=True, format="mixed").dt.tz_localize(None)
+            merged["date"] = self._parse_date_series(merged["date"])
             merged = merged.drop_duplicates(subset=["date"], keep="last").sort_values("date")
             merged.to_csv(fp, index=False)
             updated += 1

--- a/tests/misc/test_crypto_incremental_and_metadata.py
+++ b/tests/misc/test_crypto_incremental_and_metadata.py
@@ -171,3 +171,54 @@ def test_incremental_update_tz_aware_csv_dates(monkeypatch, tmp_path: Path):
     n = updater.update(end="2024-01-03")
     assert n == 1
 
+
+
+def test_incremental_update_does_not_use_pandas2_mixed_format(monkeypatch, tmp_path: Path):
+    src = tmp_path / "source"
+    src.mkdir(parents=True)
+    fp = src / "binance_btcusdt.csv"
+    pd.DataFrame(
+        {
+            "date": ["2024-01-01T00:00:00+00:00"],
+            "symbol": ["BINANCE_BTCUSDT"],
+            "open": [1],
+            "high": [1],
+            "low": [1],
+            "close": [1],
+            "volume": [1],
+            "money": [1],
+            "factor": [1],
+            "vwap": [1],
+            "trade_count": [1],
+            "exchange": ["BINANCE"],
+        }
+    ).to_csv(fp, index=False)
+
+    updater = IncrementalUpdater(str(src), exchange="binance", interval="1d")
+
+    class DummyCollector:
+        def get_data(self, symbol, interval, start, end):
+            return pd.DataFrame(
+                {
+                    "date": ["2024-01-02"],
+                    "open": [2],
+                    "high": [2],
+                    "low": [2],
+                    "close": [2],
+                    "volume": [2],
+                    "money": [4],
+                    "factor": [1],
+                    "vwap": [2],
+                    "trade_count": [2],
+                    "exchange": ["BINANCE"],
+                    "symbol": [symbol],
+                }
+            )
+
+    monkeypatch.setattr(updater, "_new_collector", lambda: DummyCollector())
+
+    n = updater.update(end="2024-01-03")
+
+    assert n == 1
+    out = pd.read_csv(fp)
+    assert out["date"].astype(str).tolist() == ["2024-01-01", "2024-01-02"]


### PR DESCRIPTION
### Motivation
- Ensure incremental updates do not depend on pandas 2.x-only parsing semantics and remain compatible with the declared `pandas>=1.1` requirement.
- Normalize timezone-aware CSV `date` values to tz-naive timestamps so start/end calculations and merges behave deterministically across mixed input formats.

### Description
- Removed use of `format="mixed"` and implemented a shared parser `IncrementalUpdater._parse_date_series` that maps values through `pd.Timestamp` and normalizes tz-aware values via the existing `_normalize_ts` helper.
- Updated `_infer_start` and the merge normalization to use `self._parse_date_series` so both start inference and merged CSV dates are parsed consistently.
- Added/updated a regression test (`test_incremental_update_does_not_use_pandas2_mixed_format`) and adjusted tz-aware test expectations to validate mixed tz-aware/naive inputs without relying on pandas 2.x behavior.

### Testing
- Ran `pytest -q tests/misc/test_crypto_incremental_and_metadata.py`.
- Result: all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afdeede5ec8322b507c71b8586b613)