### PR TITLE
Follow-up: add pandas 1.x-safe mixed date parsing in incremental updater

### DIFF
--- a/qlib_crypto/collector/incremental.py
+++ b/qlib_crypto/collector/incremental.py
@@ -53,6 +53,15 @@ class IncrementalUpdater:
             return ts.tz_convert("UTC").tz_localize(None)
         return ts
 
+    @staticmethod
+    def _parse_date_column(date_series: pd.Series) -> pd.Series:
+        """Parse mixed timestamp strings across pandas 1.x/2.x and return UTC-naive datetimes."""
+        try:
+            parsed = pd.to_datetime(date_series, utc=True, format="mixed")
+        except (TypeError, ValueError):
+            parsed = pd.to_datetime(date_series, utc=True)
+        return parsed.dt.tz_localize(None)
+
     def update(self, end: Optional[str] = None, limit_nums: Optional[int] = None):
         files = sorted(self.source_dir.glob("*.csv"))
         if limit_nums is not None:
@@ -81,7 +90,7 @@ class IncrementalUpdater:
             new_df = new_df.copy()
             new_df["symbol"] = qlib_symbol
             merged = pd.concat([old_df, new_df], sort=False, ignore_index=True)
-            merged["date"] = pd.to_datetime(merged["date"], utc=True, format="mixed").dt.tz_localize(None)
+            merged["date"] = self._parse_date_column(merged["date"])
             merged = merged.drop_duplicates(subset=["date"], keep="last").sort_values("date")
             merged.to_csv(fp, index=False)
             updated += 1


### PR DESCRIPTION
### Motivation
- Fix a high-priority runtime crash caused by calling `pd.to_datetime(..., format="mixed")`, which requires pandas 2.x and can break environments constrained to the project floor (`pandas>=1.1`).
- Ensure merged CSV `date` values are parsed into UTC-naive timestamps consistently to avoid tz-aware vs tz-naive comparison errors in `IncrementalUpdater.update()`.

### Description
- Added `IncrementalUpdater._parse_date_column(...)` that first attempts `pd.to_datetime(..., utc=True, format="mixed")` and falls back to `pd.to_datetime(..., utc=True)` on `TypeError`/`ValueError` so the code is compatible with pandas 1.x and 2.x.
- Replaced the direct call to `pd.to_datetime(..., format="mixed")` during merge normalization with `self._parse_date_column(...)` so merged `date` columns are always converted to UTC-naive datetimes.
- Kept existing `IncrementalUpdater._normalize_ts(...)` and `._infer_start(...)` behavior so `start`/`end` normalization remains unchanged.

### Testing
- Ran `pytest -q tests/misc/test_crypto_incremental_and_metadata.py -q` and all tests passed (5 tests) without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afdef2d32c8322af22315d4620a734)