### PR TITLE
Follow-up: restore pandas 1.x compatibility in incremental date merge parsing

### DIFF
--- a/qlib_crypto/collector/incremental.py
+++ b/qlib_crypto/collector/incremental.py
@@ -53,6 +53,10 @@ class IncrementalUpdater:
             return ts.tz_convert("UTC").tz_localize(None)
         return ts
 
+    @classmethod
+    def _parse_dates_compat(cls, date_series: pd.Series) -> pd.Series:
+        return date_series.apply(lambda ts: cls._normalize_ts(pd.Timestamp(ts)))
+
     def update(self, end: Optional[str] = None, limit_nums: Optional[int] = None):
         files = sorted(self.source_dir.glob("*.csv"))
         if limit_nums is not None:
@@ -81,7 +85,7 @@ class IncrementalUpdater:
             new_df = new_df.copy()
             new_df["symbol"] = qlib_symbol
             merged = pd.concat([old_df, new_df], sort=False, ignore_index=True)
-            merged["date"] = pd.to_datetime(merged["date"], utc=True, format="mixed").dt.tz_localize(None)
+            merged["date"] = self._parse_dates_compat(merged["date"])
             merged = merged.drop_duplicates(subset=["date"], keep="last").sort_values("date")
             merged.to_csv(fp, index=False)
             updated += 1

--- a/tests/misc/test_crypto_incremental_and_metadata.py
+++ b/tests/misc/test_crypto_incremental_and_metadata.py
@@ -171,3 +171,54 @@ def test_incremental_update_tz_aware_csv_dates(monkeypatch, tmp_path: Path):
     n = updater.update(end="2024-01-03")
     assert n == 1
 
+
+
+def test_incremental_update_parses_mixed_date_formats_without_pandas2_mode(monkeypatch, tmp_path: Path):
+    src = tmp_path / "source"
+    src.mkdir(parents=True)
+    fp = src / "binance_btcusdt.csv"
+    pd.DataFrame(
+        {
+            "date": ["2024-01-01"],
+            "symbol": ["BINANCE_BTCUSDT"],
+            "open": [1],
+            "high": [1],
+            "low": [1],
+            "close": [1],
+            "volume": [1],
+            "money": [1],
+            "factor": [1],
+            "vwap": [1],
+            "trade_count": [1],
+            "exchange": ["BINANCE"],
+        }
+    ).to_csv(fp, index=False)
+
+    updater = IncrementalUpdater(str(src), exchange="binance", interval="1d")
+
+    class DummyCollector:
+        def get_data(self, symbol, interval, start, end):
+            return pd.DataFrame(
+                {
+                    "date": ["2024-01-02T00:00:00Z"],
+                    "open": [2],
+                    "high": [2],
+                    "low": [2],
+                    "close": [2],
+                    "volume": [2],
+                    "money": [4],
+                    "factor": [1],
+                    "vwap": [2],
+                    "trade_count": [2],
+                    "exchange": ["BINANCE"],
+                    "symbol": [symbol],
+                }
+            )
+
+    monkeypatch.setattr(updater, "_new_collector", lambda: DummyCollector())
+
+    n = updater.update(end="2024-01-03")
+    assert n == 1
+    out = pd.read_csv(fp)
+    assert len(out) == 2
+    assert out["date"].astype(str).tolist() == ["2024-01-01", "2024-01-02"]


### PR DESCRIPTION
### Motivation
- Remove a pandas-2-only parsing dependency (`format="mixed"`) that caused runtime failures on pandas 1.x when `IncrementalUpdater.update()` merges mixed-format date strings.
- Preserve the existing timezone-normalization semantics so persisted timestamps remain UTC-naive and range checks remain safe. 

### Description
- Replaced the `pd.to_datetime(..., format="mixed")` call in `IncrementalUpdater.update()` with a new compatibility parser `IncrementalUpdater._parse_dates_compat()` that applies `pd.Timestamp` per element and reuses `IncrementalUpdater._normalize_ts()` to produce UTC-naive timestamps. 
- Implemented `@classmethod def _parse_dates_compat(cls, date_series: pd.Series) -> pd.Series` to parse mixed-format date strings in a pandas-version-agnostic way. 
- Updated the merge logic to set `merged["date"] = self._parse_dates_compat(merged["date"])` and added a regression test `test_incremental_update_parses_mixed_date_formats_without_pandas2_mode` to cover mixed `YYYY-MM-DD` and ISO8601 `Z` inputs. 

### Testing
- Ran `pytest -q tests/misc/test_crypto_incremental_and_metadata.py -q` and all tests passed. 
- Verified that `test_incremental_update_tz_aware_csv_dates` and the new `test_incremental_update_parses_mixed_date_formats_without_pandas2_mode` both succeed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afdef59dcc83228ee85dd91813744b)