### PR TITLE
Follow-up: pandas 1.x-safe datetime parsing in incremental updater

### DIFF
--- a/qlib_crypto/collector/incremental.py
+++ b/qlib_crypto/collector/incremental.py
@@ -53,6 +53,15 @@ class IncrementalUpdater:
             return ts.tz_convert("UTC").tz_localize(None)
         return ts
 
+    @staticmethod
+    def _parse_dates_utc_naive(date_values) -> pd.Series:
+        try:
+            parsed = pd.to_datetime(date_values, utc=True, format="mixed")
+        except TypeError:
+            series = date_values if isinstance(date_values, pd.Series) else pd.Series(date_values)
+            parsed = series.map(lambda value: pd.to_datetime(value, utc=True))
+        return parsed.dt.tz_localize(None)
+
     def update(self, end: Optional[str] = None, limit_nums: Optional[int] = None):
         files = sorted(self.source_dir.glob("*.csv"))
         if limit_nums is not None:
@@ -81,7 +90,7 @@ class IncrementalUpdater:
             new_df = new_df.copy()
             new_df["symbol"] = qlib_symbol
             merged = pd.concat([old_df, new_df], sort=False, ignore_index=True)
-            merged["date"] = pd.to_datetime(merged["date"], utc=True, format="mixed").dt.tz_localize(None)
+            merged["date"] = self._parse_dates_utc_naive(merged["date"])
             merged = merged.drop_duplicates(subset=["date"], keep="last").sort_values("date")
             merged.to_csv(fp, index=False)
             updated += 1

--- a/tests/misc/test_crypto_incremental_and_metadata.py
+++ b/tests/misc/test_crypto_incremental_and_metadata.py
@@ -171,3 +171,19 @@ def test_incremental_update_tz_aware_csv_dates(monkeypatch, tmp_path: Path):
     n = updater.update(end="2024-01-03")
     assert n == 1
 
+
+
+def test_parse_dates_utc_naive_falls_back_when_mixed_unsupported(monkeypatch):
+    original_to_datetime = pd.to_datetime
+
+    def fake_to_datetime(*args, **kwargs):
+        if kwargs.get("format") == "mixed":
+            raise TypeError("format='mixed' is not supported")
+        return original_to_datetime(*args, **kwargs)
+
+    monkeypatch.setattr("qlib_crypto.collector.incremental.pd.to_datetime", fake_to_datetime)
+
+    parsed = IncrementalUpdater._parse_dates_utc_naive(["2024-01-01", "2024-01-02T00:00:00+00:00"])
+    assert str(parsed.dtype) == "datetime64[ns]"
+    assert parsed.iloc[0] == pd.Timestamp("2024-01-01")
+    assert parsed.iloc[1] == pd.Timestamp("2024-01-02")


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes on environments using `pandas` 1.x where `pd.to_datetime(..., format="mixed")` raises `TypeError`, which would break `IncrementalUpdater.update()` when merging date columns.

### Description
- Added a helper `IncrementalUpdater._parse_dates_utc_naive(...)` that first attempts `pd.to_datetime(..., utc=True, format="mixed")` and falls back to element-wise `pd.to_datetime(..., utc=True)` when `TypeError` is raised. 
- Replaced the direct call to `pd.to_datetime(..., format="mixed")` in the merge path with `self._parse_dates_utc_naive(merged["date"])` so merged dates are normalized to UTC-naive timestamps in a pandas-1-compatible way. 
- Added a regression test `test_parse_dates_utc_naive_falls_back_when_mixed_unsupported` that monkeypatches `pd.to_datetime` to simulate pandas-1 behavior and verifies the fallback path parses mixed date inputs correctly.

### Testing
- Ran `pytest -q tests/misc/test_crypto_incremental_and_metadata.py -q` and the suite passed. 
- The added regression test validates the fallback behavior on simulated pandas-1 failure and succeeded as part of the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afdef422e483228e0636245011c234)