### PR TITLE
fix(crypto): restore pandas 1.x-compatible date parsing in IncrementalUpdater

### DIFF
--- a/qlib_crypto/collector/incremental.py
+++ b/qlib_crypto/collector/incremental.py
@@ -81,7 +81,8 @@ class IncrementalUpdater:
             new_df = new_df.copy()
             new_df["symbol"] = qlib_symbol
             merged = pd.concat([old_df, new_df], sort=False, ignore_index=True)
-            merged["date"] = pd.to_datetime(merged["date"], utc=True, format="mixed").dt.tz_localize(None)
+            parsed_dates = merged["date"].map(lambda v: pd.to_datetime(v, utc=True))
+            merged["date"] = pd.DatetimeIndex(parsed_dates).tz_localize(None)
             merged = merged.drop_duplicates(subset=["date"], keep="last").sort_values("date")
             merged.to_csv(fp, index=False)
             updated += 1


### PR DESCRIPTION
### Motivation
- Fix a high-priority regression where `pd.to_datetime(..., format="mixed")` (pandas 2-only) caused runtime failures on pandas 1.x when merging CSVs with mixed tz-aware and tz-naive dates.
- Ensure incremental updates continue to normalize timestamps to tz-naive UTC while remaining compatible with the repository's supported pandas range (`pandas>=1.1`).

### Description
- Replace the pandas-2-only call with a pandas-1.x-safe parsing path in `qlib_crypto/collector/incremental.py` by parsing each date value with `pd.to_datetime(value, utc=True)` and then converting to a tz-naive index via `pd.DatetimeIndex(...).tz_localize(None)`.
- Keep the downstream behavior unchanged by deduplicating on `date`, sorting, and writing the merged CSV as before.
- The change is localized to the `IncrementalUpdater.update` flow where CSV rows are concatenated and normalized.

### Testing
- Ran `pytest -q tests/misc/test_crypto_incremental_and_metadata.py` which exercises the incremental updater including the tz-aware CSV case.
- Result: all tests in that file passed (5 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afe3f141508322b2498bbcd2600981)