### PR TITLE
Handle ValueError when pandas 1.x rejects format='mixed'

### DIFF
--- a/qlib_crypto/collector/incremental.py
+++ b/qlib_crypto/collector/incremental.py
@@ -57,7 +57,7 @@ class IncrementalUpdater:
     def _parse_dates_utc_naive(date_values) -> pd.Series:
         try:
             parsed = pd.to_datetime(date_values, utc=True, format="mixed")
-        except TypeError:
+        except (TypeError, ValueError):
             series = date_values if isinstance(date_values, pd.Series) else pd.Series(date_values)
             parsed = series.map(lambda value: pd.to_datetime(value, utc=True))
         return parsed.dt.tz_localize(None)

--- a/tests/misc/test_crypto_incremental_and_metadata.py
+++ b/tests/misc/test_crypto_incremental_and_metadata.py
@@ -176,14 +176,20 @@ def test_incremental_update_tz_aware_csv_dates(monkeypatch, tmp_path: Path):
 def test_parse_dates_utc_naive_falls_back_when_mixed_unsupported(monkeypatch):
     original_to_datetime = pd.to_datetime
 
-    def fake_to_datetime(*args, **kwargs):
-        if kwargs.get("format") == "mixed":
-            raise TypeError("format='mixed' is not supported")
-        return original_to_datetime(*args, **kwargs)
+    def make_fake_to_datetime(mixed_exc):
+        def fake_to_datetime(*args, **kwargs):
+            if kwargs.get("format") == "mixed":
+                raise mixed_exc("format='mixed' is not supported")
+            return original_to_datetime(*args, **kwargs)
 
-    monkeypatch.setattr("qlib_crypto.collector.incremental.pd.to_datetime", fake_to_datetime)
+        return fake_to_datetime
 
-    parsed = IncrementalUpdater._parse_dates_utc_naive(["2024-01-01", "2024-01-02T00:00:00+00:00"])
-    assert str(parsed.dtype) == "datetime64[ns]"
-    assert parsed.iloc[0] == pd.Timestamp("2024-01-01")
-    assert parsed.iloc[1] == pd.Timestamp("2024-01-02")
+    for mixed_exc in (TypeError, ValueError):
+        monkeypatch.setattr(
+            "qlib_crypto.collector.incremental.pd.to_datetime",
+            make_fake_to_datetime(mixed_exc),
+        )
+        parsed = IncrementalUpdater._parse_dates_utc_naive(["2024-01-01", "2024-01-02T00:00:00+00:00"])
+        assert str(parsed.dtype) == "datetime64[ns]"
+        assert parsed.iloc[0] == pd.Timestamp("2024-01-01")
+        assert parsed.iloc[1] == pd.Timestamp("2024-01-02")


### PR DESCRIPTION
### Motivation
- Some pandas 1.x versions treat `format="mixed"` as an invalid format and raise `ValueError`, which caused `IncrementalUpdater.update()` to crash instead of falling back to element-wise parsing.

### Description
- Updated `IncrementalUpdater._parse_dates_utc_naive` to catch both `TypeError` and `ValueError` and fall back to element-wise `pd.to_datetime(..., utc=True)` when `format="mixed"` is unsupported in `pd.to_datetime` (file `qlib_crypto/collector/incremental.py`).
- Strengthened the regression test `test_parse_dates_utc_naive_falls_back_when_mixed_unsupported` to monkeypatch `pd.to_datetime` and verify the fallback behavior for both `TypeError` and `ValueError` cases (file `tests/misc/test_crypto_incremental_and_metadata.py`).

### Testing
- Ran `pytest -q tests/misc/test_crypto_incremental_and_metadata.py -q` and the test module passed.
- The updated regression test confirms `_parse_dates_utc_naive` successfully falls back and produces UTC-naive `datetime64[ns]` results for both exception modes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afe3e4af748322b499daeac80ff3aa)