### PR TITLE
Fix pipeline： pipeline dump field filtering and zero-volume VWAP handling for crypto plugin

### DIFF
--- a/qlib_crypto/data/pipeline.py
+++ b/qlib_crypto/data/pipeline.py
@@ -42,6 +42,7 @@ def build_and_dump(
         max_workers=max_workers,
         date_field_name="date",
         symbol_field_name="symbol",
+        exclude_fields="symbol,exchange",
     ).dump()
 
 

--- a/scripts/data_collector/crypto_ohlcv/collector.py
+++ b/scripts/data_collector/crypto_ohlcv/collector.py
@@ -4,6 +4,7 @@ from abc import ABC
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+import numpy as np
 import fire
 import pandas as pd
 from loguru import logger
@@ -184,7 +185,7 @@ class CryptoCollector(BaseCollector):
         df["date"] = pd.to_datetime(df["open_time"], unit="ms", utc=True).dt.tz_convert(None)
         df["money"] = df["quote_volume"]
         df["factor"] = 1.0
-        df["vwap"] = (df["quote_volume"] / df["volume"].replace(0, pd.NA)).astype(float)
+        df["vwap"] = df["quote_volume"].div(df["volume"].replace(0, np.nan))
         df["exchange"] = "BINANCE"
         df["symbol"] = symbol
 
@@ -216,7 +217,7 @@ class CryptoCollector(BaseCollector):
         df["date"] = pd.to_datetime(df["open_time"], unit="ms", utc=True).dt.tz_convert(None)
         df["money"] = df["quote_volume"]
         df["factor"] = 1.0
-        df["vwap"] = (df["quote_volume"] / df["volume"].replace(0, pd.NA)).astype(float)
+        df["vwap"] = df["quote_volume"].div(df["volume"].replace(0, np.nan))
         df["trade_count"] = pd.NA
         df["exchange"] = "OKX"
         df["symbol"] = symbol

--- a/tests/misc/test_crypto_data_utils.py
+++ b/tests/misc/test_crypto_data_utils.py
@@ -78,3 +78,57 @@ def test_binance_pagination_logic():
     frame = c.get_data("BTCUSDT", "1d", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-10"))
     assert c.calls >= 2
     assert not frame.empty
+
+
+def test_binance_vwap_handles_zero_volume():
+    class DummyCollector(CryptoCollector):
+        def _get_binance_instruments(self):
+            return ["BTCUSDT"]
+
+        def _request_json(self, url, params=None):
+            if "exchangeInfo" in url:
+                return {"symbols": []}
+            return []
+
+    collector = DummyCollector(
+        save_dir="/tmp/crypto_test",
+        interval="1d",
+        exchange="binance",
+        quote_asset="USDT",
+        limit_nums=1,
+    )
+    raw_data = [
+        [1704067200000, "1", "2", "0.5", "1.5", "0", 1704153599000, "10", "1", "0", "0", "0"],
+        [1704153600000, "2", "3", "1", "2.5", "5", 1704239999000, "15", "1", "0", "0", "0"],
+    ]
+
+    frame = collector._to_contract_frame_binance("BTCUSDT", raw_data)
+
+    assert pd.isna(frame.loc[0, "vwap"])
+    assert frame.loc[1, "vwap"] == 3.0
+
+
+def test_okx_vwap_handles_zero_volume():
+    class DummyCollector(CryptoCollector):
+        def _get_okx_instruments(self):
+            return ["BTC-USDT"]
+
+        def _request_json(self, url, params=None):
+            return {"data": []}
+
+    collector = DummyCollector(
+        save_dir="/tmp/crypto_test",
+        interval="1d",
+        exchange="okx",
+        quote_asset="USDT",
+        limit_nums=1,
+    )
+    raw_data = [
+        ["1704067200000", "1", "2", "0.5", "1.5", "0", "0", "10", "1"],
+        ["1704153600000", "2", "3", "1", "2.5", "5", "0", "15", "1"],
+    ]
+
+    frame = collector._to_contract_frame_okx("BTC-USDT", raw_data)
+
+    assert pd.isna(frame.loc[0, "vwap"])
+    assert frame.loc[1, "vwap"] == 3.0

--- a/tests/misc/test_crypto_pipeline_and_registry.py
+++ b/tests/misc/test_crypto_pipeline_and_registry.py
@@ -18,14 +18,14 @@ def test_symbol_registry_roundtrip():
 
 
 def test_pipeline_invokes_builder_and_dump(monkeypatch, tmp_path: Path):
-    calls = {"builder": 0, "dump": 0}
+    calls = {"builder": 0, "dump": 0, "dump_kwargs": None}
 
     def fake_builder(**kwargs):
         calls["builder"] += 1
 
     class FakeDump:
         def __init__(self, **kwargs):
-            self.kwargs = kwargs
+            calls["dump_kwargs"] = kwargs
 
         def dump(self):
             calls["dump"] += 1
@@ -41,3 +41,4 @@ def test_pipeline_invokes_builder_and_dump(monkeypatch, tmp_path: Path):
 
     assert calls["builder"] == 1
     assert calls["dump"] == 1
+    assert calls["dump_kwargs"]["exclude_fields"] == "symbol,exchange"


### PR DESCRIPTION
### Motivation

- Prevent dataset dump failures when non-numeric columns (e.g. `symbol`/`exchange`) are forwarded to `DumpDataAll` which writes features as float bins. 
- Avoid runtime exceptions when computing VWAP for zero-volume candles which occur for illiquid symbols or high-frequency bars.

### Description

- Pass `exclude_fields="symbol,exchange"` into `DumpDataAll` in `qlib_crypto.data.pipeline.build_and_dump` so string columns are omitted from float bin output. 
- Change VWAP computation in the Binance and OKX contract-frame builders to safe division using `quote_volume.div(volume.replace(0, np.nan))` and add `import numpy as np` to the collector file. 
- Update the pipeline unit test to assert `exclude_fields` is forwarded to `DumpDataAll` and add unit tests that validate VWAP behavior for zero- and non-zero-volume rows for both Binance and OKX. 

### Testing

- Ran `pytest -q tests/misc/test_crypto_pipeline_and_registry.py tests/misc/test_crypto_data_utils.py` and all targeted tests passed. 
- The new/updated tests verify that `exclude_fields` is propagated to `DumpDataAll` and that VWAP is `NaN` for zero-volume bars while remaining correct for non-zero volume bars.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afe69df55083228f6d1e33743ac2b1)