### PR TITLE
Follow-up for #1: preserve merged crypto meta fields and validate dump exclusions

### DIFF
--- a/qlib_crypto/collector/crypto_meta.py
+++ b/qlib_crypto/collector/crypto_meta.py
@@ -158,5 +158,16 @@ class CryptoMetaCollector:
         if not valid:
             return pd.DataFrame(columns=self.META_COLUMNS)
         df = pd.concat(valid, ignore_index=True, sort=False)
-        df = df.sort_values(["symbol", "date"]).drop_duplicates(["symbol", "date"], keep="last")
+
+        def _last_non_null(series: pd.Series):
+            non_null = series.dropna()
+            if non_null.empty:
+                return pd.NA
+            return non_null.iloc[-1]
+
+        df = (
+            df.sort_values(["symbol", "date"])
+            .groupby(["symbol", "date"], as_index=False, sort=False)
+            .agg(_last_non_null)
+        )
         return df[self.META_COLUMNS]

--- a/tests/misc/test_crypto_meta_collector.py
+++ b/tests/misc/test_crypto_meta_collector.py
@@ -66,3 +66,39 @@ def test_merge_spot_and_meta():
     merged = merge_spot_and_meta(spot, meta)
     assert "funding_rate" in merged.columns
     assert merged.loc[0, "funding_rate"] == 0.0001
+
+
+def test_merge_meta_frames_keeps_complementary_columns():
+    c = CryptoMetaCollector()
+    funding = pd.DataFrame(
+        {
+            "date": ["2024-01-01"],
+            "symbol": ["BINANCE_BTCUSDT"],
+            "exchange": ["BINANCE"],
+            "funding_rate": [0.0001],
+            "open_interest": [pd.NA],
+            "mark_price": [42000.0],
+            "index_price": [pd.NA],
+            "basis": [pd.NA],
+            "next_funding_time": ["2024-01-01 08:00:00"],
+        }
+    )
+    open_interest = pd.DataFrame(
+        {
+            "date": ["2024-01-01"],
+            "symbol": ["BINANCE_BTCUSDT"],
+            "exchange": ["BINANCE"],
+            "funding_rate": [pd.NA],
+            "open_interest": [1000.0],
+            "mark_price": [pd.NA],
+            "index_price": [pd.NA],
+            "basis": [pd.NA],
+            "next_funding_time": [pd.NA],
+        }
+    )
+
+    merged = c.merge_meta_frames([funding, open_interest])
+
+    assert len(merged) == 1
+    assert merged.loc[0, "funding_rate"] == 0.0001
+    assert merged.loc[0, "open_interest"] == 1000.0


### PR DESCRIPTION
### Motivation

- Fix a P1 data-loss bug where merging meta frames dropped complementary funding/open-interest rows for the same `(symbol, date)` pair.
- Ensure string fields like `symbol`/`exchange` are excluded before numeric bin serialization to avoid `ValueError` during feature dumping.

### Description

- Replace `drop_duplicates` in `CryptoMetaCollector.merge_meta_frames` with a `groupby(...).agg(_last_non_null)` that returns the last non-null value per column for each `(symbol, date)` group.
- Add the regression test `test_merge_meta_frames_keeps_complementary_columns` to ensure funding and open-interest from separate frames are preserved when merged.
- Confirm `build_and_dump` forwards `exclude_fields="symbol,exchange"` into `DumpDataAll` so string columns are not serialized as floats.

### Testing

- Ran `pytest -q tests/misc/test_crypto_meta_collector.py tests/misc/test_crypto_pipeline_and_registry.py` and observed all tests passed (5 passed, 2 warnings).
- New test `test_merge_meta_frames_keeps_complementary_columns` verifies the merge behavior and passed in the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afeb9367e883228ed13a3e50fd14a4)