### PR TITLE
Follow-up: restore Python 3.8 compatibility for SymbolRegistry annotations

### DIFF
--- a/qlib_crypto/data/symbol_registry.py
+++ b/qlib_crypto/data/symbol_registry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 


### PR DESCRIPTION
### Motivation
- Prevent `TypeError: 'type' object is not subscriptable` when importing `qlib_crypto.data.symbol_registry` on Python 3.8 due to use of PEP 585 built-in generics in annotations.

### Description
- Add `from __future__ import annotations` to `qlib_crypto/data/symbol_registry.py` so annotations are evaluated lazily and the module remains importable on Python 3.8.

### Testing
- Ran `pytest -q tests/misc/test_crypto_pipeline_and_registry.py` and an import smoke check with `python - <<'PY'
from qlib_crypto.data.symbol_registry import SymbolRegistry
print(SymbolRegistry.from_qlib_symbol('OKX_BTC_USDT_SWAP'))
PY`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afeca0778083228186097c9eb67f60)