### PR TITLE
[PR #1 Follow-up] Fix metadata merge data loss in crypto collector

### DIFF
--- a/qlib_crypto/collector/crypto_meta.py
+++ b/qlib_crypto/collector/crypto_meta.py
@@ -157,6 +157,13 @@ class CryptoMetaCollector:
         valid = [f for f in frames if f is not None and not f.empty]
         if not valid:
             return pd.DataFrame(columns=self.META_COLUMNS)
+
+        def _last_non_null(series: pd.Series):
+            non_null = series.dropna()
+            if non_null.empty:
+                return pd.NA
+            return non_null.iloc[-1]
+
         df = pd.concat(valid, ignore_index=True, sort=False)
-        df = df.sort_values(["symbol", "date"]).drop_duplicates(["symbol", "date"], keep="last")
+        df = df.sort_values(["symbol", "date"]).groupby(["symbol", "date"], as_index=False, sort=False).agg(_last_non_null)
         return df[self.META_COLUMNS]

--- a/tests/misc/test_crypto_meta_collector.py
+++ b/tests/misc/test_crypto_meta_collector.py
@@ -66,3 +66,40 @@ def test_merge_spot_and_meta():
     merged = merge_spot_and_meta(spot, meta)
     assert "funding_rate" in merged.columns
     assert merged.loc[0, "funding_rate"] == 0.0001
+
+
+def test_merge_meta_frames_preserves_complementary_rows():
+    collector = CryptoMetaCollector()
+    funding = pd.DataFrame(
+        {
+            "date": [pd.Timestamp("2024-01-01")],
+            "symbol": ["BINANCE_BTCUSDT"],
+            "exchange": ["BINANCE"],
+            "funding_rate": [0.0001],
+            "open_interest": [pd.NA],
+            "mark_price": [42000.0],
+            "index_price": [pd.NA],
+            "basis": [pd.NA],
+            "next_funding_time": [pd.Timestamp("2024-01-01 08:00:00")],
+        }
+    )
+    oi = pd.DataFrame(
+        {
+            "date": [pd.Timestamp("2024-01-01")],
+            "symbol": ["BINANCE_BTCUSDT"],
+            "exchange": ["BINANCE"],
+            "funding_rate": [pd.NA],
+            "open_interest": [12345.0],
+            "mark_price": [pd.NA],
+            "index_price": [41990.0],
+            "basis": [10.0],
+            "next_funding_time": [pd.NA],
+        }
+    )
+
+    merged = collector.merge_meta_frames([funding, oi])
+    assert len(merged) == 1
+    assert merged.loc[0, "funding_rate"] == 0.0001
+    assert merged.loc[0, "open_interest"] == 12345.0
+    assert merged.loc[0, "mark_price"] == 42000.0
+    assert merged.loc[0, "index_price"] == 41990.0


### PR DESCRIPTION
### Motivation

- The collectors may emit complementary metadata rows for the same `symbol`+`date` (e.g., funding in one row, open interest in another), and the previous merge could drop one source and silently lose data. 
- The pipeline path should exclude string fields (`symbol`/`exchange`) when dumping numeric feature bins to avoid `ValueError` during serialization, so this behavior was validated.

### Description

- Changed `CryptoMetaCollector.merge_meta_frames` to group by `symbol` and `date` and aggregate using a per-column "last non-null" rule via a helper function `_last_non_null`, preserving complementary fields instead of dropping duplicates. 
- Added `test_merge_meta_frames_preserves_complementary_rows` to `tests/misc/test_crypto_meta_collector.py` to ensure funding and open-interest emitted separately are merged into a single record without data loss. 
- Verified that `build_and_dump` in `qlib_crypto/data/pipeline.py` already passes `exclude_fields="symbol,exchange"` to `DumpDataAll` and left that behavior intact, with an existing test asserting it.

### Testing

- Ran `pytest -q tests/misc/test_crypto_pipeline_and_registry.py tests/misc/test_crypto_meta_collector.py` and all tests passed. 
- The new meta-merge test confirmed preservation of complementary funding and open-interest fields in merged output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afea75cae883228f6e55b018f2d3d7)