### PR TITLE
[PR #1 follow-up] Fix DumpDataAll field filtering and zero-volume VWAP handling

### DIFF
--- a/qlib_crypto/data/pipeline.py
+++ b/qlib_crypto/data/pipeline.py
@@ -1,9 +1,24 @@
 from pathlib import Path
 
 import fire
+import pandas as pd
 
 from scripts.dump_bin import DumpDataAll
 from qlib_crypto.data.builder import build_qlib_files
+
+
+def _infer_exclude_fields(normalize_path: Path) -> str:
+    """Infer non-numeric fields and always exclude string identifiers."""
+    excluded = {"symbol", "exchange"}
+    for csv_file in sorted(normalize_path.glob("*.csv")):
+        try:
+            sample = pd.read_csv(csv_file, nrows=200)
+        except Exception:
+            continue
+        non_numeric = sample.select_dtypes(exclude=["number", "bool"]).columns
+        excluded.update(non_numeric)
+
+    return ",".join(sorted(excluded))
 
 
 def build_and_dump(
@@ -42,7 +57,7 @@ def build_and_dump(
         max_workers=max_workers,
         date_field_name="date",
         symbol_field_name="symbol",
-        exclude_fields="symbol,exchange",
+        exclude_fields=_infer_exclude_fields(normalize_path),
     ).dump()
 
 

--- a/scripts/data_collector/crypto_ohlcv/collector.py
+++ b/scripts/data_collector/crypto_ohlcv/collector.py
@@ -122,6 +122,12 @@ class CryptoCollector(BaseCollector):
     def _normalize_exchange_symbol(self, symbol: str) -> str:
         return symbol.replace("-", "_")
 
+    @staticmethod
+    def _safe_vwap(quote_volume: pd.Series, volume: pd.Series) -> pd.Series:
+        vol = pd.to_numeric(volume, errors="coerce")
+        quote = pd.to_numeric(quote_volume, errors="coerce")
+        return quote.div(vol.where(vol != 0, np.nan))
+
     def get_instrument_list(self) -> List[str]:
         if self.exchange == "binance":
             return self._get_binance_instruments()
@@ -185,7 +191,7 @@ class CryptoCollector(BaseCollector):
         df["date"] = pd.to_datetime(df["open_time"], unit="ms", utc=True).dt.tz_convert(None)
         df["money"] = df["quote_volume"]
         df["factor"] = 1.0
-        df["vwap"] = df["quote_volume"].div(df["volume"].replace(0, np.nan))
+        df["vwap"] = self._safe_vwap(df["quote_volume"], df["volume"])
         df["exchange"] = "BINANCE"
         df["symbol"] = symbol
 
@@ -217,7 +223,7 @@ class CryptoCollector(BaseCollector):
         df["date"] = pd.to_datetime(df["open_time"], unit="ms", utc=True).dt.tz_convert(None)
         df["money"] = df["quote_volume"]
         df["factor"] = 1.0
-        df["vwap"] = df["quote_volume"].div(df["volume"].replace(0, np.nan))
+        df["vwap"] = self._safe_vwap(df["quote_volume"], df["volume"])
         df["trade_count"] = pd.NA
         df["exchange"] = "OKX"
         df["symbol"] = symbol

--- a/tests/misc/test_crypto_pipeline_and_registry.py
+++ b/tests/misc/test_crypto_pipeline_and_registry.py
@@ -33,6 +33,13 @@ def test_pipeline_invokes_builder_and_dump(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(pipeline_mod, "build_qlib_files", fake_builder)
     monkeypatch.setattr(pipeline_mod, "DumpDataAll", FakeDump)
 
+    (tmp_path / "norm").mkdir(parents=True)
+    (tmp_path / "norm" / "BINANCE_BTCUSDT.csv").write_text(
+        "date,symbol,exchange,open,market_type\n"
+        "2024-01-01,BINANCE_BTCUSDT,BINANCE,1.0,spot\n",
+        encoding="utf-8",
+    )
+
     pipeline_mod.build_and_dump(
         normalize_dir=str(tmp_path / "norm"),
         qlib_dir=str(tmp_path / "qlib"),
@@ -41,4 +48,4 @@ def test_pipeline_invokes_builder_and_dump(monkeypatch, tmp_path: Path):
 
     assert calls["builder"] == 1
     assert calls["dump"] == 1
-    assert calls["dump_kwargs"]["exclude_fields"] == "symbol,exchange"
+    assert calls["dump_kwargs"]["exclude_fields"] == "date,exchange,market_type,symbol"


### PR DESCRIPTION
### Motivation

- Prevent string/non-numeric columns from being forwarded to `DumpDataAll` where every field is float-cast, which previously caused `ValueError` during dataset dump. 
- Avoid `TypeError` / incorrect VWAP values when bars contain zero `volume` by ensuring VWAP computation safely handles zero-volume candles.

### Description

- Add `_infer_exclude_fields(normalize_path: Path)` in `qlib_crypto/data/pipeline.py` to scan normalized CSVs, always exclude `symbol` and `exchange`, and exclude any non-numeric columns; pass the inferred string (comma-separated) to `DumpDataAll` via `exclude_fields` instead of a static list. 
- Add `CryptoCollector._safe_vwap(quote_volume, volume)` in `scripts/data_collector/crypto_ohlcv/collector.py` which coerces to numeric and masks zero volumes as `NaN` before division, and use it in both Binance and OKX contract-frame conversion paths. 
- Update unit test `tests/misc/test_crypto_pipeline_and_registry.py` to create a realistic normalized CSV and assert the inferred `exclude_fields` includes string/date-like columns (e.g. ``date,exchange,market_type,symbol``).

### Testing

- Ran the focused test set with: `pytest -q tests/misc/test_crypto_pipeline_and_registry.py tests/misc/test_crypto_data_utils.py`, and all tests passed (`7 passed`) with 2 warnings related to `to_datetime` parsing; the VWAP zero-volume behavior tests confirmed `NaN` for zero-volume bars and correct values otherwise. 
- The updated pipeline unit test verifies the inferred `exclude_fields` behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afea227c5883228f8965783345451d)