### PR TITLE
Fix Codex review issues in crypto pipeline/meta merge

### DIFF
--- a/qlib_crypto/collector/crypto_meta.py
+++ b/qlib_crypto/collector/crypto_meta.py
@@ -158,5 +158,17 @@ class CryptoMetaCollector:
         if not valid:
             return pd.DataFrame(columns=self.META_COLUMNS)
         df = pd.concat(valid, ignore_index=True, sort=False)
-        df = df.sort_values(["symbol", "date"]).drop_duplicates(["symbol", "date"], keep="last")
-        return df[self.META_COLUMNS]
+        df = df.sort_values(["symbol", "date"])
+
+        def _last_valid(series: pd.Series):
+            non_null = series.dropna()
+            if non_null.empty:
+                return pd.NA
+            return non_null.iloc[-1]
+
+        merged = (
+            df.groupby(["symbol", "date", "exchange"], as_index=False, sort=False)
+            .agg({col: _last_valid for col in self.META_COLUMNS if col not in {"symbol", "date", "exchange"}})
+            .sort_values(["symbol", "date", "exchange"])
+        )
+        return merged[self.META_COLUMNS]

--- a/tests/misc/test_crypto_meta_collector.py
+++ b/tests/misc/test_crypto_meta_collector.py
@@ -66,3 +66,39 @@ def test_merge_spot_and_meta():
     merged = merge_spot_and_meta(spot, meta)
     assert "funding_rate" in merged.columns
     assert merged.loc[0, "funding_rate"] == 0.0001
+
+
+def test_merge_meta_frames_preserves_complementary_rows():
+    collector = CryptoMetaCollector()
+    funding = pd.DataFrame(
+        {
+            "date": ["2024-01-01 00:00:00"],
+            "symbol": ["BINANCE_BTCUSDT"],
+            "exchange": ["BINANCE"],
+            "funding_rate": [0.0001],
+            "open_interest": [pd.NA],
+            "mark_price": [42000],
+            "index_price": [41990],
+            "basis": [10],
+            "next_funding_time": ["2024-01-01 08:00:00"],
+        }
+    )
+    oi = pd.DataFrame(
+        {
+            "date": ["2024-01-01 00:00:00"],
+            "symbol": ["BINANCE_BTCUSDT"],
+            "exchange": ["BINANCE"],
+            "funding_rate": [pd.NA],
+            "open_interest": [1000],
+            "mark_price": [pd.NA],
+            "index_price": [pd.NA],
+            "basis": [pd.NA],
+            "next_funding_time": [pd.NA],
+        }
+    )
+
+    merged = collector.merge_meta_frames([funding, oi])
+
+    assert len(merged) == 1
+    assert merged.loc[0, "funding_rate"] == 0.0001
+    assert merged.loc[0, "open_interest"] == 1000


### PR DESCRIPTION
### Motivation

- Prevent pipeline crashes when dumping normalized CSVs by ensuring string identifier fields are excluded from numeric bin serialization. 
- Preserve complementary metadata (funding rate and open interest) when collectors emit separate rows for the same `symbol`/`date` so no data is silently lost before downstream joins.

### Description

- Verified `build_and_dump` forwards `exclude_fields="symbol,exchange"` into `DumpDataAll` to avoid float-cast errors during feature bin dumping (`qlib_crypto/data/pipeline.py`).
- Reworked `merge_meta_frames` in `qlib_crypto/collector/crypto_meta.py` to `groupby` on `symbol/date/exchange` and aggregate metadata columns by taking the last non-null value per field instead of dropping duplicate rows, thereby preserving funding and open-interest emitted in separate frames.
- Added `test_merge_meta_frames_preserves_complementary_rows` to `tests/misc/test_crypto_meta_collector.py` to guard the merge behavior.

### Testing

- Ran targeted tests with `pytest -q tests/misc/test_crypto_pipeline_and_registry.py tests/misc/test_crypto_meta_collector.py`, which passed (`5 passed, 2 warnings`).
- The new unit test `test_merge_meta_frames_preserves_complementary_rows` passed and verifies that funding and open-interest from complementary rows are retained after merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afea1ea90083228191faa60bd0a377)