### PR TITLE
Preserve merged meta fields and validate dump exclusions

### DIFF
--- a/qlib_crypto/collector/crypto_meta.py
+++ b/qlib_crypto/collector/crypto_meta.py
@@ -157,6 +157,18 @@ class CryptoMetaCollector:
         valid = [f for f in frames if f is not None and not f.empty]
         if not valid:
             return pd.DataFrame(columns=self.META_COLUMNS)
-        df = pd.concat(valid, ignore_index=True, sort=False)
-        df = df.sort_values(["symbol", "date"]).drop_duplicates(["symbol", "date"], keep="last")
-        return df[self.META_COLUMNS]
+        df = pd.concat(valid, ignore_index=True, sort=False).sort_values(["symbol", "date"]) 
+
+        def _last_non_null(s: pd.Series):
+            non_null = s.dropna()
+            if non_null.empty:
+                return pd.NA
+            return non_null.iloc[-1]
+
+        agg_map = {col: _last_non_null for col in self.META_COLUMNS if col not in {"symbol", "date"}}
+        merged = (
+            df.groupby(["symbol", "date"], as_index=False, sort=True)
+            .agg(agg_map)
+            .reindex(columns=self.META_COLUMNS)
+        )
+        return merged

--- a/tests/misc/test_crypto_meta_collector.py
+++ b/tests/misc/test_crypto_meta_collector.py
@@ -66,3 +66,44 @@ def test_merge_spot_and_meta():
     merged = merge_spot_and_meta(spot, meta)
     assert "funding_rate" in merged.columns
     assert merged.loc[0, "funding_rate"] == 0.0001
+
+
+def test_merge_meta_frames_preserves_complementary_fields():
+    collector = CryptoMetaCollector()
+    dt = pd.Timestamp("2024-01-01")
+
+    funding = pd.DataFrame(
+        {
+            "date": [dt],
+            "symbol": ["BINANCE_BTCUSDT"],
+            "exchange": ["BINANCE"],
+            "funding_rate": [0.0002],
+            "open_interest": [pd.NA],
+            "mark_price": [42000.0],
+            "index_price": [pd.NA],
+            "basis": [pd.NA],
+            "next_funding_time": [pd.Timestamp("2024-01-01 08:00:00")],
+        }
+    )
+    open_interest = pd.DataFrame(
+        {
+            "date": [dt],
+            "symbol": ["BINANCE_BTCUSDT"],
+            "exchange": ["BINANCE"],
+            "funding_rate": [pd.NA],
+            "open_interest": [1234.5],
+            "mark_price": [pd.NA],
+            "index_price": [41990.0],
+            "basis": [10.0],
+            "next_funding_time": [pd.NA],
+        }
+    )
+
+    merged = collector.merge_meta_frames([funding, open_interest])
+
+    assert len(merged) == 1
+    assert merged.loc[0, "funding_rate"] == 0.0002
+    assert merged.loc[0, "open_interest"] == 1234.5
+    assert merged.loc[0, "mark_price"] == 42000.0
+    assert merged.loc[0, "index_price"] == 41990.0
+    assert merged.loc[0, "basis"] == 10.0


### PR DESCRIPTION
### Motivation

- Fix a high-priority bug where separate metadata collectors (funding vs open-interest) produced complementary rows for the same `symbol`/`date` and the previous dedup step silently dropped one source, losing values.
- Ensure the pipeline path excludes string columns before serializing feature bins to avoid float-cast errors when dumping CSV-derived fields.

### Description

- Updated `CryptoMetaCollector.merge_meta_frames` in `qlib_crypto/collector/crypto_meta.py` to `groupby` on `['symbol','date']` and aggregate each metadata column by taking the last non-null value instead of dropping duplicate rows, preserving complementary fields across sources.
- Added a regression test `test_merge_meta_frames_preserves_complementary_fields` in `tests/misc/test_crypto_meta_collector.py` that constructs split funding and open-interest rows for the same timestamp and verifies both values are retained after merge.
- Confirmed `qlib_crypto/data/pipeline.py` already invokes `DumpDataAll` with `exclude_fields="symbol,exchange"`, preventing string columns from being serialized as floats (no code change required in the pipeline file).

### Testing

- Ran targeted tests: `pytest -q tests/misc/test_crypto_pipeline_and_registry.py tests/misc/test_crypto_meta_collector.py` and they all passed.
- Test run results: `5 passed, 2 warnings` (warnings are unrelated `setuptools_scm` / pandas concat future-warning messages).
- The new regression test verifies that merged metadata retains funding, open-interest and related complementary fields when collectors emit separate rows for the same `symbol`/`date`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afe850a0f08322a36a63bd872b76b7)