### PR TITLE
[PR #1 follow-up] Fix SymbolRegistry import on Python 3.8

### DIFF
--- a/qlib_crypto/data/symbol_registry.py
+++ b/qlib_crypto/data/symbol_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Tuple
 
 
 @dataclass(frozen=True)
@@ -12,6 +13,6 @@ class SymbolRegistry:
         return f"{exchange.upper()}_{symbol.replace('-', '_')}"
 
     @staticmethod
-    def from_qlib_symbol(qlib_symbol: str) -> tuple[str, str]:
+    def from_qlib_symbol(qlib_symbol: str) -> Tuple[str, str]:
         ex, raw = qlib_symbol.split("_", 1)
         return ex.upper(), raw.replace("_", "-") if ex.upper() == "OKX" else raw


### PR DESCRIPTION
### Motivation
- Prevent `TypeError: 'type' object is not subscriptable` when importing `qlib_crypto.data.symbol_registry` on Python 3.8 by avoiding runtime evaluation of PEP 585 generics.

### Description
- Replace the PEP 585 return annotation with a backport-safe typing alias by adding `from typing import Tuple` and changing the signature to `def from_qlib_symbol(qlib_symbol: str) -> Tuple[str, str]:` in `qlib_crypto/data/symbol_registry.py`.

### Testing
- Ran the focused test `pytest -q tests/misc/test_crypto_pipeline_and_registry.py::test_symbol_registry_roundtrip`, which passed; the full file run `pytest -q tests/misc/test_crypto_pipeline_and_registry.py` exhibits a pre-existing unrelated failure in `test_pipeline_invokes_builder_and_dump` (assertion mismatch for `exclude_fields`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aff01ec4c08322b7d90adc49d019ad)