### PR TITLE
Add test for deferred return annotation on SymbolRegistry.from_qlib_symbol

### DIFF
--- a/tests/misc/test_crypto_pipeline_and_registry.py
+++ b/tests/misc/test_crypto_pipeline_and_registry.py
@@ -17,6 +17,12 @@ def test_symbol_registry_roundtrip():
     assert raw == "BTC-USDT-SWAP"
 
 
+def test_symbol_registry_return_annotation_is_deferred_string():
+    # Guard Python 3.8 compatibility: with postponed evaluation enabled,
+    # built-in generic annotations are stored as strings instead of evaluated.
+    assert SymbolRegistry.from_qlib_symbol.__annotations__["return"] == "tuple[str, str]"
+
+
 def test_pipeline_invokes_builder_and_dump(monkeypatch, tmp_path: Path):
     calls = {"builder": 0, "dump": 0, "dump_kwargs": None}
 


### PR DESCRIPTION
### Motivation
- Ensure compatibility with Python 3.8's postponed evaluation of annotations by asserting that `SymbolRegistry.from_qlib_symbol` records its return type as the string `"tuple[str, str]"`.

### Description
- Add `test_symbol_registry_return_annotation_is_deferred_string` to `tests/misc/test_crypto_pipeline_and_registry.py` which verifies that `SymbolRegistry.from_qlib_symbol.__annotations__["return"] == "tuple[str, str]"`.

### Testing
- Ran the updated test module with `pytest tests/misc/test_crypto_pipeline_and_registry.py` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aff01ec4c08322b7d90adc49d019ad)