### PR TITLE
Fix incremental updater timezone alignment for default end path

### DIFF
--- a/qlib_crypto/collector/incremental.py
+++ b/qlib_crypto/collector/incremental.py
@@ -41,8 +41,8 @@ class IncrementalUpdater:
         )
 
     def _infer_start(self, df: pd.DataFrame) -> pd.Timestamp:
-        date_series = pd.to_datetime(df["date"], utc=True)
-        last_dt = date_series.max().tz_localize(None)
+        date_series = pd.to_datetime(df["date"], utc=True, format="mixed")
+        last_dt = self._normalize_ts(date_series.max())
         step = pd.Timedelta(days=1) if self.interval == "1d" else pd.Timedelta(minutes=1)
         return pd.Timestamp(last_dt) + step
 
@@ -70,7 +70,7 @@ class IncrementalUpdater:
                 continue
             qlib_symbol = str(old_df["symbol"].iloc[0])
             raw_symbol = _to_exchange_symbol(self.exchange, qlib_symbol)
-            start_ts = self._infer_start(old_df)
+            start_ts = self._normalize_ts(self._infer_start(old_df))
             if start_ts >= end_ts:
                 continue
             new_df = collector.get_data(raw_symbol, self.interval, start_ts, end_ts)


### PR DESCRIPTION
### Motivation

- Prevent `TypeError` raised when `IncrementalUpdater.update()` compares tz-aware `end` (default) with tz-naive start timestamps inferred from CSV files.

### Description

- Parse CSV `date` values with `pd.to_datetime(..., utc=True, format="mixed")` and route the max date through `_normalize_ts()` in `_infer_start()` so inferred starts are consistently UTC-naive.
- Normalize `start_ts` with `self._normalize_ts(...)` right before comparing to `end_ts` and before passing timestamps to the collector to avoid tz-aware vs tz-naive comparisons.
- Retain the existing `_normalize_ts()` helper that converts tz-aware timestamps to UTC-naive via `tz_convert("UTC").tz_localize(None)`.

### Testing

- Executed a focused regression script that creates a sample CSV and runs `IncrementalUpdater.update()` with the default `end`, and it returned `1` while assertions in the dummy collector confirmed `start` and `end` are tz-naive (succeeded).
- Ran `pytest -q tests/misc/test_crypto_incremental_and_metadata.py`, but test collection failed due to an unrelated `IndentationError` in `qlib_crypto/collector/crypto_meta.py` (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aff1c3a63c8322a18c2960d89c79c9)