### PR TITLE
fix(packaging): include qlib_crypto and scripts in distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,10 +112,10 @@ client = [
 # InvalidDistribution: Invalid distribution metadata: unrecognized or malformed field 'license-file'
 # To solve this problem, we added license-files here. Refs: https://github.com/pypa/twine/issues/1216
 [tool.setuptools]
-packages = [
-  "qlib",
-]
 license-files = []
+
+[tool.setuptools.packages.find]
+include = ["qlib", "qlib.*", "qlib_crypto", "qlib_crypto.*", "scripts"]
 
 [project.scripts]
 qrun = "qlib.cli.run:run"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged script utilities exposed for runtime integrations."""


### PR DESCRIPTION
### Motivation

- Ensure the newly added `qlib_crypto` plugin and the runtime `scripts.dump_bin` utility are present in built distributions so non-editable installs don't raise `ModuleNotFoundError` and crypto features are importable.

### Description

- Updated packaging to use `setuptools` package discovery in `pyproject.toml` and include `qlib`, `qlib.*`, `qlib_crypto`, `qlib_crypto.*`, and `scripts`, and added `scripts/__init__.py` to make `scripts` an importable package so `from scripts.dump_bin import DumpDataAll` works in installed environments.

### Testing

- Verified module importability and basic runtime sanity with `python -m compileall qlib_crypto/data/pipeline.py scripts/__init__.py`, a runtime import check of `qlib_crypto.data.pipeline` (confirmed `build_and_dump` present), and an import check of `scripts.dump_bin` (confirmed `DumpDataAll` present); attempted wheel build with `python -m build --wheel --no-isolation` but the environment lacked the `build` module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aff35345e88322be7f49d52804bac4)